### PR TITLE
Generalize Needleman-Wunsch alignment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPCRAnalysis"
 uuid = "c1d73f9e-d42a-418a-8d5b-c7b00ec0358f"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/src/GPCRAnalysis.jl
+++ b/src/GPCRAnalysis.jl
@@ -30,7 +30,7 @@ using GZip
 
 export @res_str
 
-export SequenceMapping, AccessionCode, MSACode
+export SequenceMapping, AccessionCode, MSACode, NWGapCosts
 export species, uniprotX, query_uniprot_accession
 export try_download_alphafold, query_alphafold_latest, download_alphafolds, alphafoldfile, alphafoldfiles, getchain, findall_subseq
 export align_to_axes, align_to_membrane, align_nw, align_ranges

--- a/src/pocket.jl
+++ b/src/pocket.jl
@@ -25,7 +25,7 @@ end
 function scvector(r::PDBResidue)
     cacoord = alphacarbon_coordinates(r)
     sccoord = sidechaincentroid(r)
-    return sccoord === nothing ? [0.0,0.0,0.0] : sccoord - cacoord
+    return sccoord === nothing ? zero(cacoord) : sccoord - cacoord
 end
 
 function res_inside_hull(sccoord, tmcoords) # tmcoords is a list of 2D points in the z-plane of sccoord


### PR DESCRIPTION
The initial application of NW alignment was to find TM anchors. In that
case, one is aligning a "probe" structure to 14 specific "reference
residues," and thus the problem is quite asymmetric. There are
applications where we would rather do "symmetric" alignment. This is
basically a complete rewrite of the NW alignment code to allow for this.

With the centroid/sidechain distance-based penalty, recommended gapcosts
are: 5Å for extend, 20Å for open. These approximately maximize the
agreement with the MSA pairings.