### PR TITLE
Recognize '|' as accession code terminator

### DIFF
--- a/src/naming_conventions.jl
+++ b/src/naming_conventions.jl
@@ -46,8 +46,8 @@ function species(name::AbstractString)
     return m.captures[1]::AbstractString
 end
 
-const rex_uniprotX_Swiss = r"^([A-Z0-9]{1,5})($|_)"   # Swiss
-const rex_uniprot_accession = r"^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})(?:$|_|\.\d+)"
+const rex_uniprotX_Swiss = r"^([A-Z0-9]{1,5})(?:$|_)"   # Swiss
+const rex_uniprot_accession = r"^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})(?:$|_|\||\.\d+)"
 
 """
     uniprotX(name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,8 @@ using Test
         @test @inferred(GPCRAnalysis.strip_residue_range("Q8VGW6_MOUSE/31-308")) == "Q8VGW6_MOUSE"
         @test @inferred(species("Q8VGW6_MOUSE/31-308")) == "MOUSE"
         @test @inferred(uniprotX("Q8VGW6_MOUSE/31-308")) == "Q8VGW6"
+        # ClusalOmega MSA codes
+        @test uniprotX("Q5QD11|reviewed|Trace") == "Q5QD11"
         # Examples from https://www.uniprot.org/help/accession_numbers
         @test @inferred(uniprotX("A2BC19")) == "A2BC19"
         @test @inferred(uniprotX("P12345")) == "P12345"


### PR DESCRIPTION
With the revisions to https://github.com/diegozea/MIToS.jl/pull/75, we
need to recognize `|` as a terminator for the accession code.