### PR TITLE
Optionally suppress warnings in `align`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPCRAnalysis"
 uuid = "c1d73f9e-d42a-418a-8d5b-c7b00ec0358f"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/src/align.jl
+++ b/src/align.jl
@@ -7,11 +7,11 @@
 Return a rotated and shifted version of `moving` so that the α-carbons of residues `moving[sm]` have least
 mean square error deviation from positions `fixedpos` or those of residues `fixed`.
 """
-function align(fixedpos::AbstractMatrix{Float64}, moving::AbstractVector{PDBResidue}, sm::SequenceMapping; seqname=nothing)
+function align(fixedpos::AbstractMatrix{Float64}, moving::AbstractVector{PDBResidue}, sm::SequenceMapping; seqname=nothing, warn::Bool=true)
     length(sm) == size(fixedpos, 2) || throw(DimensionMismatch("reference has $(size(fixedpos, 2)) positions, but `sm` has $(length(sm))"))
     movres = moving[sm]
     keep = map(!isnothing, movres)
-    if !all(keep)
+    if !all(keep) && warn
         @warn "missing $(length(keep)-sum(keep)) anchors for sequence $seqname"
     end
     movpos = residue_centroid_matrix(movres[keep])


### PR DESCRIPTION
This adds a keyword to skip warnings about missing anchor residues.