### PR TITLE
Fix Uniprot decompression and refresh EBI test accessions

### DIFF
--- a/src/naming_conventions.jl
+++ b/src/naming_conventions.jl
@@ -166,9 +166,12 @@ Check the status of a Uniprot ID mapping job. Returns `true` if the results are
 ready. Otherwise, returns the status object.
 """
 function map_uniprot_status(jobID)
-    resp = HTTP.get("https://rest.uniprot.org/idmapping/status/$jobID", ["Accept" => "application/json"]; decompress = true)
+    # `decompress = false` suppresses the `Accept-Encoding: gzip` request header, so the
+    # body arrives as plain text. Uniprot does not always honor a compression request, and
+    # unconditionally gunzipping the response fails whenever it returns one uncompressed.
+    resp = HTTP.get("https://rest.uniprot.org/idmapping/status/$jobID", ["Accept" => "application/json"]; decompress = false)
     if resp.status == 200
-        status = JSON3.read(String(HTTP.decode(resp)))
+        status = JSON3.read(String(resp.body))
         haskey(status, "results") && return true
         return status
     end
@@ -181,9 +184,9 @@ end
 Retrieve the results of a Uniprot ID mapping job.
 """
 function map_uniprot_retrieve(jobID)
-    resp = HTTP.get("https://rest.uniprot.org/idmapping/stream/$jobID", ["Accept" => "application/json"]; decompress = true)
+    resp = HTTP.get("https://rest.uniprot.org/idmapping/stream/$jobID", ["Accept" => "application/json"]; decompress = false)
     if resp.status == 200
-        return JSON3.read(String(HTTP.decode(resp)))
+        return JSON3.read(String(resp.body))
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,7 +418,9 @@ using Test
                 end
             end
             @test startswith(query_ebi_proteins("Q7TQA6"; format=:fasta), ">sp|Q7TQA6")
-            @test count(==('>'), query_ebi_proteins(["C3N734", "H2C869", "Q3V4T1", "P20220"]; format=:fasta)) == 4
+            # Reviewed (SwissProt) accessions: unreviewed entries get withdrawn when
+            # the underlying genome annotation changes, silently shrinking the count.
+            @test count(==('>'), query_ebi_proteins(["P29274", "P29275", "P15409", "Q7TQA6"]; format=:fasta)) == 4
             q = query_ncbi(obj)
             @test q["total_count"] == 1
         end


### PR DESCRIPTION
Uniprot serves ID-mapping responses uncompressed unless the client negotiates gzip, and does not always honor the request when it does. Requesting compression and then unconditionally gunzipping the response therefore fails intermittently with a ZlibError. Suppress the Accept-Encoding header via `decompress = false` and read the body directly.

The EBI batch-query test used accession C3N734, which has since been withdrawn from Uniprot, so the query returned three records instead of four. Reviewed (SwissProt) accessions are not withdrawn the way unreviewed entries are; use four GPCR entries already exercised elsewhere in the suite.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>